### PR TITLE
Dev

### DIFF
--- a/lib/apimodules/ADSModule.ts
+++ b/lib/apimodules/ADSModule.ts
@@ -517,10 +517,12 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
+     * @param {boolean} force  True
      * @return {Promise<void>}
      */
-    async RefreshRemoteConfigStores(): Promise<void> {
+    async RefreshRemoteConfigStores(force: boolean): Promise<void> {
         return this.apiCall("ADSModule/RefreshRemoteConfigStores", { 
+            force
         });
     }
 
@@ -722,9 +724,9 @@ export class ADSModule extends AMPAPI {
      * @param {any} MemoryPolicy  False
      * @param {any} ContainerMaxCPU  False
      * @param {string} ContainerImage  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async UpdateInstanceInfo(InstanceId: string, FriendlyName: string, Description: string, StartOnBoot: boolean, Suspended: boolean, ExcludeFromFirewall: boolean, RunInContainer: boolean, ContainerMemory: number, MemoryPolicy: any, ContainerMaxCPU: any, ContainerImage: string): Promise<Task<ActionResult<any>>> {
+    async UpdateInstanceInfo(InstanceId: string, FriendlyName: string, Description: string, StartOnBoot: boolean, Suspended: boolean, ExcludeFromFirewall: boolean, RunInContainer: boolean, ContainerMemory: number, MemoryPolicy: any, ContainerMaxCPU: any, ContainerImage: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/UpdateInstanceInfo", { 
             InstanceId,
             FriendlyName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralnexus/ampapi",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "author": "p0t4t0sandwich <p0t4t0sandwich@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated Methods in AMP v2.4.6.8:

- `ADSModule.RefreshRemoteConfigStores` has a new parameter, `force: Boolean`
- `ADSModule.UpdateInstanceInfo` now returns `ActionResult` rather than `Task<ActionResult>`

```diff
- ADSModule.RefreshRemoteConfigStores() -> Void
+ ADSModule.RefreshRemoteConfigStores(force: Boolean) -> Void

- ADSModule.UpdateInstanceInfo(InstanceId: String, FriendlyName: String, Description: String, StartOnBoot: Boolean, Suspended: Boolean, ExcludeFromFirewall: Boolean, RunInContainer: Boolean, ContainerMemory: Int32, MemoryPolicy: ContainerMemoryPolicy, ContainerMaxCPU: Single, ContainerImage: String) -> Task<ActionResult>
+ ADSModule.UpdateInstanceInfo(InstanceId: String, FriendlyName: String, Description: String, StartOnBoot: Boolean, Suspended: Boolean, ExcludeFromFirewall: Boolean, RunInContainer: Boolean, ContainerMemory: Int32, MemoryPolicy: ContainerMemoryPolicy, ContainerMaxCPU: Single, ContainerImage: String) -> ActionResult
```