### PR TITLE
Update to AMP v2.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ const API = new ADS("http://localhost:8080/", "admin", "myfancypassword123");
 await API.APILogin();
 
 // Get the available instances
-const instancesResult = await API.ADSModule.GetInstances();
-
-const targets = instancesResult.result;
+const targets = await API.ADSModule.GetInstances();
 
 // In this example, my Hub server is on the second target
 // If you're running a standalone setup, you can just use targets[0]

--- a/index.ts
+++ b/index.ts
@@ -18,9 +18,9 @@ import { GenericModule } from "./lib/modules/GenericModule.js";
 import { Minecraft } from "./lib/modules/Minecraft.js";
 
 // Import types
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LicenceInfo, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, UUID } from "./lib/types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LicenceInfo, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, UUID } from "./lib/types.js";
 
 // Export everything
 export { AMPAPI, ADSModule, Core, EmailSenderPlugin, FileManagerPlugin, LocalFileBackupPlugin, MinecraftModule, RCONPlugin, steamcmdplugin, ADS, CommonAPI, GenericModule, Minecraft };
-export { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LicenceInfo, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, UUID };
+export { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LicenceInfo, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, UUID };
 export default AMPAPI;

--- a/lib/AMPAPI.ts
+++ b/lib/AMPAPI.ts
@@ -76,15 +76,21 @@ export class AMPAPI {
             headers: {
                 'Content-Type': 'application/json',
                 'Accept': 'text/javascript',
-                'User-Agent': 'ampapi-js/1.0.4'
+                'User-Agent': 'ampapi-js/1.0.14'
             },
             body: JSON.stringify({ ...data, ...session })
         });
 
         // Check if the response is valid
         if (response.ok) {
+            // Check for API errors
+            const json = await response.json();
+            if (json != null && (json.hasOwnProperty("Title") || json.hasOwnProperty("Message") || json.hasOwnProperty("StackTrace"))) {
+                throw new Error(`API call failed: ${json.Title}: ${json.Message}\n${json.StackTrace}`);
+            }
+
             // Return the response
-            return response.json();
+            return json;
         } else {
             // Throw an error
             throw new Error("API call failed");

--- a/lib/apimodules/ADSModule.ts
+++ b/lib/apimodules/ADSModule.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**
@@ -36,9 +36,9 @@ export class ADSModule extends AMPAPI {
      * @param {UUID} InstanceID  False
      * @param {{ [key: string]: string }} Args  False
      * @param {boolean} RebuildConfiguration  True
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async ApplyInstanceConfiguration(InstanceID: UUID, Args: { [key: string]: string }, RebuildConfiguration: boolean): Promise<Task<ActionResult<any>>> {
+    async ApplyInstanceConfiguration(InstanceID: UUID, Args: { [key: string]: string }, RebuildConfiguration: boolean): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/ApplyInstanceConfiguration", { 
             InstanceID,
             Args,
@@ -196,9 +196,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} InstanceName  False
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async DeleteInstance(InstanceName: string): Promise<Result<RunningTask>> {
+    async DeleteInstance(InstanceName: string): Promise<RunningTask> {
         return this.apiCall("ADSModule/DeleteInstance", { 
             InstanceName
         });
@@ -207,9 +207,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} InstanceId  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async DeleteInstanceUsers(InstanceId: UUID): Promise<Task<ActionResult<any>>> {
+    async DeleteInstanceUsers(InstanceId: UUID): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/DeleteInstanceUsers", { 
             InstanceId
         });
@@ -227,9 +227,9 @@ export class ADSModule extends AMPAPI {
      * @param {string} Secret Must be a non-empty strong in order to get a callback on deployment state change. This secret will be passed back to you in the callback so you can verify the request. True
      * @param {any} PostCreate 0: Do nothing, 1: Start instance only, 2: Start instance and update application, 3: Full application startup. True
      * @param {{ [key: string]: string }} ExtraProvisionSettings A dictionary of setting nodes and values to create the new instance with. Identical in function to the provisioning arguments in the template itself. True
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async DeployTemplate(TemplateID: number, NewUsername: string, NewPassword: string, NewEmail: string, RequiredTags: string[], Tag: string, FriendlyName: string, Secret: string, PostCreate: any, ExtraProvisionSettings: { [key: string]: string }): Promise<Result<RunningTask>> {
+    async DeployTemplate(TemplateID: number, NewUsername: string, NewPassword: string, NewEmail: string, RequiredTags: string[], Tag: string, FriendlyName: string, Secret: string, PostCreate: any, ExtraProvisionSettings: { [key: string]: string }): Promise<RunningTask> {
         return this.apiCall("ADSModule/DeployTemplate", { 
             TemplateID,
             NewUsername,
@@ -258,9 +258,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} SourceArchive  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async ExtractEverywhere(SourceArchive: string): Promise<Task<ActionResult<any>>> {
+    async ExtractEverywhere(SourceArchive: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/ExtractEverywhere", { 
             SourceArchive
         });
@@ -269,9 +269,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} instanceId  False
-     * @return {Promise<Result<EndpointInfo[]>>}
+     * @return {Promise<EndpointInfo[]>}
      */
-    async GetApplicationEndpoints(instanceId: UUID): Promise<Result<EndpointInfo[]>> {
+    async GetApplicationEndpoints(instanceId: UUID): Promise<EndpointInfo[]> {
         return this.apiCall("ADSModule/GetApplicationEndpoints", { 
             instanceId
         });
@@ -291,9 +291,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {number} datastoreId  False
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetDatastoreInstances(datastoreId: number): Promise<Result<{ [key: string]: any }[]>> {
+    async GetDatastoreInstances(datastoreId: number): Promise<{ [key: string]: any }[]> {
         return this.apiCall("ADSModule/GetDatastoreInstances", { 
             datastoreId
         });
@@ -301,18 +301,18 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<InstanceDatastore[]>>}
+     * @return {Promise<InstanceDatastore[]>}
      */
-    async GetDatastores(): Promise<Result<InstanceDatastore[]>> {
+    async GetDatastores(): Promise<InstanceDatastore[]> {
         return this.apiCall("ADSModule/GetDatastores", { 
         });
     }
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetDeploymentTemplates(): Promise<Result<any[]>> {
+    async GetDeploymentTemplates(): Promise<any[]> {
         return this.apiCall("ADSModule/GetDeploymentTemplates", { 
         });
     }
@@ -320,9 +320,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} GroupId  False
-     * @return {Promise<Result<IADSInstance>>}
+     * @return {Promise<IADSInstance>}
      */
-    async GetGroup(GroupId: UUID): Promise<Result<IADSInstance>> {
+    async GetGroup(GroupId: UUID): Promise<IADSInstance> {
         return this.apiCall("ADSModule/GetGroup", { 
             GroupId
         });
@@ -331,9 +331,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} InstanceId  False
-     * @return {Promise<Result<Instance>>}
+     * @return {Promise<Instance>}
      */
-    async GetInstance(InstanceId: UUID): Promise<Result<Instance>> {
+    async GetInstance(InstanceId: UUID): Promise<Instance> {
         return this.apiCall("ADSModule/GetInstance", { 
             InstanceId
         });
@@ -342,9 +342,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} InstanceName  False
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetInstanceNetworkInfo(InstanceName: string): Promise<Result<any[]>> {
+    async GetInstanceNetworkInfo(InstanceName: string): Promise<any[]> {
         return this.apiCall("ADSModule/GetInstanceNetworkInfo", { 
             InstanceName
         });
@@ -352,27 +352,27 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetInstanceStatuses(): Promise<Result<{ [key: string]: any }[]>> {
+    async GetInstanceStatuses(): Promise<{ [key: string]: any }[]> {
         return this.apiCall("ADSModule/GetInstanceStatuses", { 
         });
     }
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<IADSInstance[]>>}
+     * @return {Promise<IADSInstance[]>}
      */
-    async GetInstances(): Promise<Result<IADSInstance[]>> {
+    async GetInstances(): Promise<IADSInstance[]> {
         return this.apiCall("ADSModule/GetInstances", { 
         });
     }
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetLocalInstances(): Promise<Result<{ [key: string]: any }[]>> {
+    async GetLocalInstances(): Promise<{ [key: string]: any }[]> {
         return this.apiCall("ADSModule/GetLocalInstances", { 
         });
     }
@@ -380,9 +380,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} ModuleName  False
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetProvisionArguments(ModuleName: string): Promise<Result<{ [key: string]: any }[]>> {
+    async GetProvisionArguments(ModuleName: string): Promise<{ [key: string]: any }[]> {
         return this.apiCall("ADSModule/GetProvisionArguments", { 
             ModuleName
         });
@@ -399,18 +399,18 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetSupportedApplications(): Promise<Result<any[]>> {
+    async GetSupportedApplications(): Promise<any[]> {
         return this.apiCall("ADSModule/GetSupportedApplications", { 
         });
     }
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<RemoteTargetInfo>>}
+     * @return {Promise<RemoteTargetInfo>}
      */
-    async GetTargetInfo(): Promise<Result<RemoteTargetInfo>> {
+    async GetTargetInfo(): Promise<RemoteTargetInfo> {
         return this.apiCall("ADSModule/GetTargetInfo", { 
         });
     }
@@ -420,9 +420,9 @@ export class ADSModule extends AMPAPI {
      * @param {string} ForModule  False
      * @param {string} SettingNode  False
      * @param {string[]} Values  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async HandoutInstanceConfigs(ForModule: string, SettingNode: string, Values: string[]): Promise<Task<ActionResult<any>>> {
+    async HandoutInstanceConfigs(ForModule: string, SettingNode: string, Values: string[]): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/HandoutInstanceConfigs", { 
             ForModule,
             SettingNode,
@@ -449,9 +449,9 @@ export class ADSModule extends AMPAPI {
      * @param {any} Protocol  False
      * @param {string} Description  False
      * @param {boolean} Open  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async ModifyCustomFirewallRule(instanceId: UUID, PortNumber: number, Range: number, Protocol: any, Description: string, Open: boolean): Promise<Task<ActionResult<any>>> {
+    async ModifyCustomFirewallRule(instanceId: UUID, PortNumber: number, Range: number, Protocol: any, Description: string, Open: boolean): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/ModifyCustomFirewallRule", { 
             instanceId,
             PortNumber,
@@ -466,9 +466,9 @@ export class ADSModule extends AMPAPI {
      * Name Description Optional
      * @param {UUID} instanceId  False
      * @param {number} datastoreId  False
-     * @return {Promise<Task<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async MoveInstanceDatastore(instanceId: UUID, datastoreId: number): Promise<Task<RunningTask>> {
+    async MoveInstanceDatastore(instanceId: UUID, datastoreId: number): Promise<RunningTask> {
         return this.apiCall("ADSModule/MoveInstanceDatastore", { 
             instanceId,
             datastoreId
@@ -477,9 +477,9 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async ReactivateLocalInstances(): Promise<Result<RunningTask>> {
+    async ReactivateLocalInstances(): Promise<RunningTask> {
         return this.apiCall("ADSModule/ReactivateLocalInstances", { 
         });
     }
@@ -507,9 +507,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} InstanceId  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async RefreshInstanceConfig(InstanceId: string): Promise<Task<ActionResult<any>>> {
+    async RefreshInstanceConfig(InstanceId: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/RefreshInstanceConfig", { 
             InstanceId
         });
@@ -534,9 +534,9 @@ export class ADSModule extends AMPAPI {
      * @param {string} password  False
      * @param {string} twoFactorToken  False
      * @param {string} friendlyName  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async RegisterTarget(controllerUrl: string, myUrl: string, username: string, password: string, twoFactorToken: string, friendlyName: string): Promise<Task<ActionResult<any>>> {
+    async RegisterTarget(controllerUrl: string, myUrl: string, username: string, password: string, twoFactorToken: string, friendlyName: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/RegisterTarget", { 
             controllerUrl,
             myUrl,
@@ -550,9 +550,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {number} id  False
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async RepairDatastore(id: number): Promise<Result<RunningTask>> {
+    async RepairDatastore(id: number): Promise<RunningTask> {
         return this.apiCall("ADSModule/RepairDatastore", { 
             id
         });
@@ -561,9 +561,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {number} datastoreId  False
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async RequestDatastoreSizeCalculation(datastoreId: number): Promise<Result<RunningTask>> {
+    async RequestDatastoreSizeCalculation(datastoreId: number): Promise<RunningTask> {
         return this.apiCall("ADSModule/RequestDatastoreSizeCalculation", { 
             datastoreId
         });
@@ -584,9 +584,9 @@ export class ADSModule extends AMPAPI {
      * Name Description Optional
      * @param {string} id  False
      * @param {string} REQ_RAWJSON  False
-     * @return {Promise<Task<{ [key: string]: any }>>}
+     * @return {Promise<{ [key: string]: any }>}
      */
-    async Servers(id: string, REQ_RAWJSON: string): Promise<Task<{ [key: string]: any }>> {
+    async Servers(id: string, REQ_RAWJSON: string): Promise<{ [key: string]: any }> {
         return this.apiCall("ADSModule/Servers", { 
             id,
             REQ_RAWJSON
@@ -598,9 +598,9 @@ export class ADSModule extends AMPAPI {
      * @param {string} InstanceName  False
      * @param {string} SettingNode  False
      * @param {string} Value  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async SetInstanceConfig(InstanceName: string, SettingNode: string, Value: string): Promise<Task<ActionResult<any>>> {
+    async SetInstanceConfig(InstanceName: string, SettingNode: string, Value: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/SetInstanceConfig", { 
             InstanceName,
             SettingNode,
@@ -612,9 +612,9 @@ export class ADSModule extends AMPAPI {
      * Name Description Optional
      * @param {UUID} InstanceId  False
      * @param {{ [key: string]: number }} PortMappings  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async SetInstanceNetworkInfo(InstanceId: UUID, PortMappings: { [key: string]: number }): Promise<Task<ActionResult<any>>> {
+    async SetInstanceNetworkInfo(InstanceId: UUID, PortMappings: { [key: string]: number }): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/SetInstanceNetworkInfo", { 
             InstanceId,
             PortMappings
@@ -625,9 +625,9 @@ export class ADSModule extends AMPAPI {
      * Name Description Optional
      * @param {string} InstanceName  False
      * @param {boolean} Suspended  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async SetInstanceSuspended(InstanceName: string, Suspended: boolean): Promise<Task<ActionResult<any>>> {
+    async SetInstanceSuspended(InstanceName: string, Suspended: boolean): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/SetInstanceSuspended", { 
             InstanceName,
             Suspended
@@ -636,9 +636,9 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async StartAllInstances(): Promise<Task<ActionResult<any>>> {
+    async StartAllInstances(): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/StartAllInstances", { 
         });
     }
@@ -646,9 +646,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} InstanceName  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async StartInstance(InstanceName: string): Promise<Task<ActionResult<any>>> {
+    async StartInstance(InstanceName: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/StartInstance", { 
             InstanceName
         });
@@ -656,9 +656,9 @@ export class ADSModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async StopAllInstances(): Promise<Task<ActionResult<any>>> {
+    async StopAllInstances(): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/StopAllInstances", { 
         });
     }
@@ -679,9 +679,9 @@ export class ADSModule extends AMPAPI {
      * @param {string} url  False
      * @param {string} username  False
      * @param {string} password  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async TestADSLoginDetails(url: string, username: string, password: string): Promise<Task<ActionResult<any>>> {
+    async TestADSLoginDetails(url: string, username: string, password: string): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/TestADSLoginDetails", { 
             url,
             username,
@@ -757,12 +757,12 @@ export class ADSModule extends AMPAPI {
      * Name Description Optional
      * @param {UUID} Id  False
      * @param {string} FriendlyName  False
-     * @param {string} Url  False
+     * @param {URL} Url  False
      * @param {string} Description  False
      * @param {string[]} Tags  False
      * @return {Promise<ActionResult<any>>}
      */
-    async UpdateTargetInfo(Id: UUID, FriendlyName: string, Url: string, Description: string, Tags: string[]): Promise<ActionResult<any>> {
+    async UpdateTargetInfo(Id: UUID, FriendlyName: string, Url: URL, Description: string, Tags: string[]): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/UpdateTargetInfo", { 
             Id,
             FriendlyName,
@@ -775,9 +775,9 @@ export class ADSModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {boolean} RestartRunning  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async UpgradeAllInstances(RestartRunning: boolean): Promise<Task<ActionResult<any>>> {
+    async UpgradeAllInstances(RestartRunning: boolean): Promise<ActionResult<any>> {
         return this.apiCall("ADSModule/UpgradeAllInstances", { 
             RestartRunning
         });

--- a/lib/apimodules/Core.ts
+++ b/lib/apimodules/Core.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**
@@ -33,9 +33,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} LicenceKey  False
      * @param {boolean} QueryOnly  True
-     * @return {Promise<Task<ActionResult<LicenceInfo>>>}
+     * @return {Promise<ActionResult<LicenceInfo>>}
      */
-    async ActivateAMPLicence(LicenceKey: string, QueryOnly: boolean): Promise<Task<ActionResult<LicenceInfo>>> {
+    async ActivateAMPLicence(LicenceKey: string, QueryOnly: boolean): Promise<ActionResult<LicenceInfo>> {
         return this.apiCall("Core/ActivateAMPLicence", { 
             LicenceKey,
             QueryOnly
@@ -92,9 +92,9 @@ export class Core extends AMPAPI {
     /**
      * DEV: Async test method
      * Name Description Optional
-     * @return {Promise<Task<string>>}
+     * @return {Promise<string>}
      */
-    async AsyncTest(): Promise<Task<string>> {
+    async AsyncTest(): Promise<string> {
         return this.apiCall("Core/AsyncTest", { 
         });
     }
@@ -131,9 +131,9 @@ export class Core extends AMPAPI {
      * @param {string} OldPassword  False
      * @param {string} NewPassword  False
      * @param {string} TwoFactorPIN  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async ChangeUserPassword(Username: string, OldPassword: string, NewPassword: string, TwoFactorPIN: string): Promise<Task<ActionResult<any>>> {
+    async ChangeUserPassword(Username: string, OldPassword: string, NewPassword: string, TwoFactorPIN: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/ChangeUserPassword", { 
             Username,
             OldPassword,
@@ -146,9 +146,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} Username  False
      * @param {string} TwoFactorCode  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async ConfirmTwoFactorSetup(Username: string, TwoFactorCode: string): Promise<Task<ActionResult<any>>> {
+    async ConfirmTwoFactorSetup(Username: string, TwoFactorCode: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/ConfirmTwoFactorSetup", { 
             Username,
             TwoFactorCode
@@ -159,9 +159,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} Name  False
      * @param {boolean} AsCommonRole  True
-     * @return {Promise<Task<ActionResult<UUID>>>}
+     * @return {Promise<ActionResult<UUID>>}
      */
-    async CreateRole(Name: string, AsCommonRole: boolean): Promise<Task<ActionResult<UUID>>> {
+    async CreateRole(Name: string, AsCommonRole: boolean): Promise<ActionResult<UUID>> {
         return this.apiCall("Core/CreateRole", { 
             Name,
             AsCommonRole
@@ -181,9 +181,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} Username  False
-     * @return {Promise<Task<ActionResult<UUID>>>}
+     * @return {Promise<ActionResult<UUID>>}
      */
-    async CreateUser(Username: string): Promise<Task<ActionResult<UUID>>> {
+    async CreateUser(Username: string): Promise<ActionResult<UUID>> {
         return this.apiCall("Core/CreateUser", { 
             Username
         });
@@ -203,9 +203,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} InstanceId  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async DeleteInstanceUsers(InstanceId: UUID): Promise<Task<ActionResult<any>>> {
+    async DeleteInstanceUsers(InstanceId: UUID): Promise<ActionResult<any>> {
         return this.apiCall("Core/DeleteInstanceUsers", { 
             InstanceId
         });
@@ -214,9 +214,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} RoleId  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async DeleteRole(RoleId: UUID): Promise<Task<ActionResult<any>>> {
+    async DeleteRole(RoleId: UUID): Promise<ActionResult<any>> {
         return this.apiCall("Core/DeleteRole", { 
             RoleId
         });
@@ -249,9 +249,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} Username  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async DeleteUser(Username: string): Promise<Task<ActionResult<any>>> {
+    async DeleteUser(Username: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/DeleteUser", { 
             Username
         });
@@ -261,9 +261,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} Password  False
      * @param {string} TwoFactorCode  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async DisableTwoFactor(Password: string, TwoFactorCode: string): Promise<Task<ActionResult<any>>> {
+    async DisableTwoFactor(Password: string, TwoFactorCode: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/DisableTwoFactor", { 
             Password,
             TwoFactorCode
@@ -332,9 +332,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} Username  False
      * @param {string} Password  False
-     * @return {Promise<Task<any>>}
+     * @return {Promise<ActionResult<Any>>}
      */
-    async EnableTwoFactor(Username: string, Password: string): Promise<Task<any>> {
+    async EnableTwoFactor(Username: string, Password: string): Promise<ActionResult<Any>> {
         return this.apiCall("Core/EnableTwoFactor", { 
             Username,
             Password
@@ -355,9 +355,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} RoleId  False
-     * @return {Promise<Task<string[]>>}
+     * @return {Promise<string[]>}
      */
-    async GetAMPRolePermissions(RoleId: UUID): Promise<Task<string[]>> {
+    async GetAMPRolePermissions(RoleId: UUID): Promise<string[]> {
         return this.apiCall("Core/GetAMPRolePermissions", { 
             RoleId
         });
@@ -366,9 +366,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} Username  False
-     * @return {Promise<Task<UserInfo>>}
+     * @return {Promise<UserInfo>}
      */
-    async GetAMPUserInfo(Username: string): Promise<Task<UserInfo>> {
+    async GetAMPUserInfo(Username: string): Promise<UserInfo> {
         return this.apiCall("Core/GetAMPUserInfo", { 
             Username
         });
@@ -376,9 +376,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetAMPUsersSummary(): Promise<Task<any[]>> {
+    async GetAMPUsersSummary(): Promise<any[]> {
         return this.apiCall("Core/GetAMPUsersSummary", { 
         });
     }
@@ -394,18 +394,18 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetActiveAMPSessions(): Promise<Result<any[]>> {
+    async GetActiveAMPSessions(): Promise<any[]> {
         return this.apiCall("Core/GetActiveAMPSessions", { 
         });
     }
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<UserInfo[]>>}
+     * @return {Promise<UserInfo[]>}
      */
-    async GetAllAMPUserInfo(): Promise<Task<UserInfo[]>> {
+    async GetAllAMPUserInfo(): Promise<UserInfo[]> {
         return this.apiCall("Core/GetAllAMPUserInfo", { 
         });
     }
@@ -414,9 +414,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {any} Before  False
      * @param {number} Count  False
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetAuditLogEntries(Before: any, Count: number): Promise<Result<any[]>> {
+    async GetAuditLogEntries(Before: any, Count: number): Promise<any[]> {
         return this.apiCall("Core/GetAuditLogEntries", { 
             Before,
             Count
@@ -437,9 +437,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string[]} nodes  False
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetConfigs(nodes: string[]): Promise<Result<{ [key: string]: any }[]>> {
+    async GetConfigs(nodes: string[]): Promise<{ [key: string]: any }[]> {
         return this.apiCall("Core/GetConfigs", { 
             nodes
         });
@@ -456,9 +456,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<ModuleInfo>>}
+     * @return {Promise<ModuleInfo>}
      */
-    async GetModuleInfo(): Promise<Result<ModuleInfo>> {
+    async GetModuleInfo(): Promise<ModuleInfo> {
         return this.apiCall("Core/GetModuleInfo", { 
         });
     }
@@ -483,9 +483,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetPortSummaries(): Promise<Result<any[]>> {
+    async GetPortSummaries(): Promise<any[]> {
         return this.apiCall("Core/GetPortSummaries", { 
         });
     }
@@ -503,9 +503,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} Description  True
      * @param {boolean} IsTemporary  True
-     * @return {Promise<Task<string>>}
+     * @return {Promise<string>}
      */
-    async GetRemoteLoginToken(Description: string, IsTemporary: boolean): Promise<Task<string>> {
+    async GetRemoteLoginToken(Description: string, IsTemporary: boolean): Promise<string> {
         return this.apiCall("Core/GetRemoteLoginToken", { 
             Description,
             IsTemporary
@@ -515,9 +515,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} RoleId  False
-     * @return {Promise<Task<Object>>}
+     * @return {Promise<any>}
      */
-    async GetRole(RoleId: UUID): Promise<Task<Object>> {
+    async GetRole(RoleId: UUID): Promise<any> {
         return this.apiCall("Core/GetRole", { 
             RoleId
         });
@@ -525,18 +525,18 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetRoleData(): Promise<Task<any[]>> {
+    async GetRoleData(): Promise<any[]> {
         return this.apiCall("Core/GetRoleData", { 
         });
     }
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<Map<UUID, any>>>}
+     * @return {Promise<{ [key: UUID]: string }>}
      */
-    async GetRoleIds(): Promise<Task<Map<UUID, any>>> {
+    async GetRoleIds(): Promise<{ [key: UUID]: string }> {
         return this.apiCall("Core/GetRoleIds", { 
         });
     }
@@ -565,9 +565,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<SettingsSpec>}
+     * @return {Promise<{ [key: string]: SettingSpec }>}
      */
-    async GetSettingsSpec(): Promise<SettingsSpec> {
+    async GetSettingsSpec(): Promise<{ [key: string]: SettingSpec }> {
         return this.apiCall("Core/GetSettingsSpec", { 
         });
     }
@@ -583,9 +583,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<RunningTask[]>>}
+     * @return {Promise<RunningTask[]>}
      */
-    async GetTasks(): Promise<Result<RunningTask[]>> {
+    async GetTasks(): Promise<RunningTask[]> {
         return this.apiCall("Core/GetTasks", { 
         });
     }
@@ -603,9 +603,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<UpdateInfo>>}
+     * @return {Promise<UpdateInfo>}
      */
-    async GetUpdateInfo(): Promise<Result<UpdateInfo>> {
+    async GetUpdateInfo(): Promise<UpdateInfo> {
         return this.apiCall("Core/GetUpdateInfo", { 
         });
     }
@@ -632,9 +632,9 @@ export class Core extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} UID  False
-     * @return {Promise<{ [key: string]: any }>}
+     * @return {Promise<any>}
      */
-    async GetUserInfo(UID: string): Promise<{ [key: string]: any }> {
+    async GetUserInfo(UID: string): Promise<any> {
         return this.apiCall("Core/GetUserInfo", { 
             UID
         });
@@ -643,9 +643,9 @@ export class Core extends AMPAPI {
     /**
      * Returns a list of in-application users
      * Name Description Optional
-     * @return {Promise<Result<{ [key: string]: string }>>}
+     * @return {Promise<{ [key: string]: string }>}
      */
-    async GetUserList(): Promise<Result<{ [key: string]: string }>> {
+    async GetUserList(): Promise<{ [key: string]: string }> {
         return this.apiCall("Core/GetUserList", { 
         });
     }
@@ -672,9 +672,9 @@ export class Core extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetWebauthnCredentialSummaries(): Promise<Result<any[]>> {
+    async GetWebauthnCredentialSummaries(): Promise<any[]> {
         return this.apiCall("Core/GetWebauthnCredentialSummaries", { 
         });
     }
@@ -747,9 +747,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {UUID} RoleId  False
      * @param {string} NewName  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async RenameRole(RoleId: UUID, NewName: string): Promise<Task<ActionResult<any>>> {
+    async RenameRole(RoleId: UUID, NewName: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/RenameRole", { 
             RoleId,
             NewName
@@ -760,9 +760,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} Username  False
      * @param {string} NewPassword  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async ResetUserPassword(Username: string, NewPassword: string): Promise<Task<ActionResult<any>>> {
+    async ResetUserPassword(Username: string, NewPassword: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/ResetUserPassword", { 
             Username,
             NewPassword
@@ -835,9 +835,9 @@ export class Core extends AMPAPI {
      * @param {UUID} RoleId  False
      * @param {string} PermissionNode  False
      * @param {boolean} Enabled  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async SetAMPRolePermission(RoleId: UUID, PermissionNode: string, Enabled: boolean): Promise<Task<ActionResult<any>>> {
+    async SetAMPRolePermission(RoleId: UUID, PermissionNode: string, Enabled: boolean): Promise<ActionResult<any>> {
         return this.apiCall("Core/SetAMPRolePermission", { 
             RoleId,
             PermissionNode,
@@ -850,9 +850,9 @@ export class Core extends AMPAPI {
      * @param {UUID} UserId  False
      * @param {UUID} RoleId  False
      * @param {boolean} IsMember  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async SetAMPUserRoleMembership(UserId: UUID, RoleId: UUID, IsMember: boolean): Promise<Task<ActionResult<any>>> {
+    async SetAMPUserRoleMembership(UserId: UUID, RoleId: UUID, IsMember: boolean): Promise<ActionResult<any>> {
         return this.apiCall("Core/SetAMPUserRoleMembership", { 
             UserId,
             RoleId,
@@ -947,9 +947,9 @@ export class Core extends AMPAPI {
      * Name Description Optional
      * @param {string} EmailAddress  False
      * @param {string} TwoFactorPIN  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async UpdateAccountInfo(EmailAddress: string, TwoFactorPIN: string): Promise<Task<ActionResult<any>>> {
+    async UpdateAccountInfo(EmailAddress: string, TwoFactorPIN: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/UpdateAccountInfo", { 
             EmailAddress,
             TwoFactorPIN
@@ -973,9 +973,9 @@ export class Core extends AMPAPI {
      * @param {boolean} CannotChangePassword  False
      * @param {boolean} MustChangePassword  False
      * @param {string} EmailAddress  True
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async UpdateUserInfo(Username: string, Disabled: boolean, PasswordExpires: boolean, CannotChangePassword: boolean, MustChangePassword: boolean, EmailAddress: string): Promise<Task<ActionResult<any>>> {
+    async UpdateUserInfo(Username: string, Disabled: boolean, PasswordExpires: boolean, CannotChangePassword: boolean, MustChangePassword: boolean, EmailAddress: string): Promise<ActionResult<any>> {
         return this.apiCall("Core/UpdateUserInfo", { 
             Username,
             Disabled,

--- a/lib/apimodules/EmailSenderPlugin.ts
+++ b/lib/apimodules/EmailSenderPlugin.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**
@@ -22,9 +22,9 @@ export class EmailSenderPlugin extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async TestSMTPSettings(): Promise<Task<ActionResult<any>>> {
+    async TestSMTPSettings(): Promise<ActionResult<any>> {
         return this.apiCall("EmailSenderPlugin/TestSMTPSettings", { 
         });
     }

--- a/lib/apimodules/FileManagerPlugin.ts
+++ b/lib/apimodules/FileManagerPlugin.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**
@@ -98,11 +98,11 @@ export class FileManagerPlugin extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @param {string} Source  False
+     * @param {URL} Source  False
      * @param {string} TargetDirectory  False
      * @return {Promise<ActionResult<any>>}
      */
-    async DownloadFileFromURL(Source: string, TargetDirectory: string): Promise<ActionResult<any>> {
+    async DownloadFileFromURL(Source: URL, TargetDirectory: string): Promise<ActionResult<any>> {
         return this.apiCall("FileManagerPlugin/DownloadFileFromURL", { 
             Source,
             TargetDirectory
@@ -145,9 +145,9 @@ export class FileManagerPlugin extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} Dir  False
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetDirectoryListing(Dir: string): Promise<Result<{ [key: string]: any }[]>> {
+    async GetDirectoryListing(Dir: string): Promise<{ [key: string]: any }[]> {
         return this.apiCall("FileManagerPlugin/GetDirectoryListing", { 
             Dir
         });

--- a/lib/apimodules/GenericModule.ts
+++ b/lib/apimodules/GenericModule.ts
@@ -8,12 +8,12 @@ import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo
 
 
 /**
- * @class RCONPlugin
+ * @class GenericModule
  */
-export class RCONPlugin extends AMPAPI {
+export class GenericModule extends AMPAPI {
     /**
      * @constructor
-     * @description Constructor for the RCONPlugin class
+     * @description Constructor for the GenericModule class
      * @param {AMPAPI} ampapi The AMP API handler
      */
     constructor(ampapi: AMPAPI) {
@@ -22,10 +22,12 @@ export class RCONPlugin extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<void>}
+     * @param {string} filename  False
+     * @return {Promise<{ [key: string]: string }>}
      */
-    async Dummy(): Promise<void> {
-        return this.apiCall("RCONPlugin/Dummy", { 
+    async ImportConfig(filename: string): Promise<{ [key: string]: string }> {
+        return this.apiCall("GenericModule/ImportConfig", { 
+            filename
         });
     }
 

--- a/lib/apimodules/LocalFileBackupPlugin.ts
+++ b/lib/apimodules/LocalFileBackupPlugin.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**
@@ -23,9 +23,9 @@ export class LocalFileBackupPlugin extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} BackupId  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async DeleteFromS3(BackupId: UUID): Promise<Task<ActionResult<any>>> {
+    async DeleteFromS3(BackupId: UUID): Promise<ActionResult<any>> {
         return this.apiCall("LocalFileBackupPlugin/DeleteFromS3", { 
             BackupId
         });
@@ -45,9 +45,9 @@ export class LocalFileBackupPlugin extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} BackupId  False
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async DownloadFromS3(BackupId: UUID): Promise<Result<RunningTask>> {
+    async DownloadFromS3(BackupId: UUID): Promise<RunningTask> {
         return this.apiCall("LocalFileBackupPlugin/DownloadFromS3", { 
             BackupId
         });
@@ -55,9 +55,9 @@ export class LocalFileBackupPlugin extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<any[]>>}
+     * @return {Promise<any[]>}
      */
-    async GetBackups(): Promise<Result<any[]>> {
+    async GetBackups(): Promise<any[]> {
         return this.apiCall("LocalFileBackupPlugin/GetBackups", { 
         });
     }
@@ -106,9 +106,9 @@ export class LocalFileBackupPlugin extends AMPAPI {
     /**
      * Name Description Optional
      * @param {UUID} BackupId  False
-     * @return {Promise<Result<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async UploadToS3(BackupId: UUID): Promise<Result<RunningTask>> {
+    async UploadToS3(BackupId: UUID): Promise<RunningTask> {
         return this.apiCall("LocalFileBackupPlugin/UploadToS3", { 
             BackupId
         });

--- a/lib/apimodules/MinecraftModule.ts
+++ b/lib/apimodules/MinecraftModule.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**
@@ -32,9 +32,9 @@ export class MinecraftModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} UserOrUUID  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async AddOPEntry(UserOrUUID: string): Promise<Task<ActionResult<any>>> {
+    async AddOPEntry(UserOrUUID: string): Promise<ActionResult<any>> {
         return this.apiCall("MinecraftModule/AddOPEntry", { 
             UserOrUUID
         });
@@ -43,9 +43,9 @@ export class MinecraftModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {string} UserOrUUID  False
-     * @return {Promise<Task<ActionResult<any>>>}
+     * @return {Promise<ActionResult<any>>}
      */
-    async AddToWhitelist(UserOrUUID: string): Promise<Task<ActionResult<any>>> {
+    async AddToWhitelist(UserOrUUID: string): Promise<ActionResult<any>> {
         return this.apiCall("MinecraftModule/AddToWhitelist", { 
             UserOrUUID
         });
@@ -74,9 +74,9 @@ export class MinecraftModule extends AMPAPI {
     /**
      * Name Description Optional
      * @param {number} pluginId  False
-     * @return {Promise<Task<RunningTask>>}
+     * @return {Promise<RunningTask>}
      */
-    async BukGetInstallUpdatePlugin(pluginId: number): Promise<Task<RunningTask>> {
+    async BukGetInstallUpdatePlugin(pluginId: number): Promise<RunningTask> {
         return this.apiCall("MinecraftModule/BukGetInstallUpdatePlugin", { 
             pluginId
         });
@@ -194,9 +194,9 @@ export class MinecraftModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async GetWhitelist(): Promise<Result<{ [key: string]: any }[]>> {
+    async GetWhitelist(): Promise<{ [key: string]: any }[]> {
         return this.apiCall("MinecraftModule/GetWhitelist", { 
         });
     }
@@ -225,9 +225,9 @@ export class MinecraftModule extends AMPAPI {
 
     /**
      * Name Description Optional
-     * @return {Promise<Result<{ [key: string]: any }[]>>}
+     * @return {Promise<{ [key: string]: any }[]>}
      */
-    async LoadOPList(): Promise<Result<{ [key: string]: any }[]>> {
+    async LoadOPList(): Promise<{ [key: string]: any }[]> {
         return this.apiCall("MinecraftModule/LoadOPList", { 
         });
     }

--- a/lib/apimodules/steamcmdplugin.ts
+++ b/lib/apimodules/steamcmdplugin.ts
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**

--- a/lib/modules/GenericModule.ts
+++ b/lib/modules/GenericModule.ts
@@ -3,6 +3,7 @@
  * @description An API that allows you to communicate with AMP installations from within JavaScript/TypeScript
  */
 
+import { GenericModule as GenericModuleAlias } from "../apimodules/GenericModule.js";
 import { RCONPlugin } from "../apimodules/RCONPlugin.js";
 import { steamcmdplugin } from "../apimodules/steamcmdplugin.js";
 import { LoginResult } from "../types.js";
@@ -12,6 +13,7 @@ import { CommonAPI } from "./CommonAPI.js";
  * @class GenericModule
  */
 export class GenericModule extends CommonAPI {
+    public GenericModule: GenericModuleAlias = new GenericModuleAlias(this);
     public RCONPlugin: RCONPlugin = new RCONPlugin(this);
     public steamcmdplugin: steamcmdplugin = new steamcmdplugin(this);
 
@@ -40,6 +42,8 @@ export class GenericModule extends CommonAPI {
             this.sessionId = loginResult.sessionID;
 
             // Update the session ID and remember me token of submodules
+            this.GenericModule.sessionId = this.sessionId;
+            this.GenericModule.rememberMeToken = this.rememberMeToken;
             this.RCONPlugin.sessionId = this.sessionId;
             this.RCONPlugin.rememberMeToken = this.rememberMeToken;
             this.steamcmdplugin.sessionId = this.sessionId;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -277,6 +277,7 @@ interface LicenceInfo {
  * @property {string} sessionID The session ID of the user
  * @property {string} rememberMeToken The remember me token of the user
  * @property {UserInfo} userInfo The user info of the user
+ * @property {string} resultReason The reason for the result
  * @property {number} result The result of the login
  */
 interface LoginResult {
@@ -285,6 +286,7 @@ interface LoginResult {
     sessionID: string;
     rememberMeToken: string;
     userInfo: UserInfo;
+    resultReason: string;
     result: number;
 }
 
@@ -422,16 +424,6 @@ interface RemoteTargetInfo {
     PlatformInfo: PlatformInfo;
     Datastores: InstanceDatastore[];
     DeploysInContainers: boolean;
-}
-
-/**
- * @interface Result
- * @author p0t4t0sandwich
- * @description Generic response type for calls that return a result
- * @property {T} result - The result of the call
- */
-interface Result<T> {
-    result: T;
 }
 
 /**
@@ -657,16 +649,6 @@ interface Status {
 }
 
 /**
- * @interface Task
- * @author p0t4t0sandwich
- * @description Generic response type for calls that return a result
- * @property {T} result - The result of the call
- */
-interface Task<T> {
-    result: T;
-}
-
-/**
  * @interface UpdateInfo
  * @author p0t4t0sandwich
  * @description An interface to represent the object returned by the ADSModule#GetUpdateInfo() method
@@ -761,13 +743,11 @@ export {
     ModuleInfo,
     PlatformInfo,
     RemoteTargetInfo,
-    Result,
     RunningTask,
     SettingsSpec,
     Spec,
     State, lookupState,
     Status,
-    Task,
     UpdateInfo,
     Updates,
     UserInfo,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neuralnexus/ampapi",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "p0t4t0sandwich <p0t4t0sandwich@gmail.com>",
   "repository": {
     "type": "git",

--- a/utils/ampapi_gen.py
+++ b/utils/ampapi_gen.py
@@ -7,99 +7,86 @@ import json
 import sys
 
 type_dict = {
-    "InstanceDatastore": "InstanceDatastore",
+    # Generic types
     "ActionResult": "ActionResult<any>",
-    "Int32": "number",
-    "IEnumerable<InstanceDatastore>": "Result<InstanceDatastore[]>",
-    "RunningTask": "Result<RunningTask>",
-    "Task<RunningTask>": "Task<RunningTask>",
-    "IEnumerable<JObject>": "Result<{ [key: string]: any }[]>",
-    "Guid": "UUID",
-    "IEnumerable<DeploymentTemplate>": "Result<any[]>",
-    "String": "string",
-    "DeploymentTemplate": "any",
-    "Boolean": "boolean",
-    "List<String>": "string[]",
-    "PostCreateActions": "any",
-    "Dictionary<String, String>": "{ [key: string]: string }",
-    "RemoteTargetInfo": "RemoteTargetInfo",
-    "IEnumerable<ApplicationSpec>": "Result<any[]>",
-    "Void": "void",
-    "IEnumerable<EndpointInfo>": "Result<EndpointInfo[]>",
-    "IEnumerable<IADSInstance>": "Result<IADSInstance[]>",
-    "JObject": "{ [key: string]: any }",
-    "PortProtocol": "any",
+    "ActionResult<Guid>": "ActionResult<UUID>",
+    "ActionResult<LicenceInfo>": "ActionResult<LicenceInfo>",
     "ActionResult<String>": "ActionResult<string>",
-    "IADSInstance": "Result<IADSInstance>",
-    "Uri": "string",
-    "IEnumerable<PortUsage>": "Result<any[]>",
-    "Dictionary<String, Int32>": "{ [key: string]: number }",
-    "LocalAMPInstance": "any",
-    "ContainerMemoryPolicy": "any",
-    "Single": "any",
-    "Int64": "number",
-    "FileChunkData": "any",
-    "IEnumerable<BackupManifest>": "Result<any[]>",
-    "Nullable<DateTime>": "any", # Optional?
-    "IEnumerable<IAuditLogEntry>": "Result<any[]>",
-    "Dictionary<String, IEnumerable<JObject>>": "Result<{ [key: string]: { [key: string]: any }[] }>",
-    "IDictionary<String, String>": "{ [key: string]: string }",
-    "List<JObject>": "{ [key: string]: any }[]",
-    "String[]": "string[]",
-    "Nullable<Boolean>": "boolean", # Optional?
-    "ScheduleInfo": "any",
-    "Int32[]": "number[]",
-    "TimeIntervalTrigger": "any",
-    "IEnumerable<WebSessionSummary>": "Result<any[]>",
-    "IList<IPermissionsTreeNode>": "any[]",
-    "WebauthnLoginInfo": "any",
-    "IEnumerable<WebauthnCredentialSummary>": "Result<any[]>",
-    "IEnumerable<RunningTask>": "Result<RunningTask[]>",
-    "ModuleInfo": "Result<ModuleInfo>",
-    "Dictionary<String, Dictionary<String, MethodInfoSummary>>": "{ [key: string]: { [key: string]: any } }",
-    "Object": "any",
-    "UpdateInfo": "Result<UpdateInfo>",
-    "IEnumerable<ListeningPortSummary>": "Result<any[]>",
-    "Task<JObject>": "Task<{ [key: string]: any }>",
-    "Task<ActionResult<TwoFactorSetupInfo>>": "Task<any>",
-    "Task<IEnumerable<String>>": "Task<string[]>",
-    "Task<UserInfo>": "Task<UserInfo>",
-    "Task<IEnumerable<UserInfoSummary>>": "Task<any[]>",
-    "Task<IEnumerable<UserInfo>>": "Task<UserInfo[]>",
-    "Task<String>": "Task<string>",
-    "Task<AuthRoleSummary>": "Task<Object>",
-    "Task<IEnumerable<AuthRoleSummary>>": "Task<any[]>",
-    "Task<IDictionary<Guid, String>>": "Task<Map<UUID, any>>",
-    "Task<ActionResult>": "Task<ActionResult<any>>",
-    "Task<ActionResult<Guid>>": "Task<ActionResult<UUID>>",
-    "Task<ActionResult<LicenceInfo>>": "Task<ActionResult<LicenceInfo>>",
+    "ActionResult<TwoFactorSetupInfo>": "ActionResult<Any>",
+    "RunningTask": "RunningTask",
+    "IEnumerable<RunningTask>": "RunningTask[]",
 
-    ## Custom types
-    "Result<Instance>": "Result<Instance>",
-    "Result<RemoteTargetInfo>": "Result<RemoteTargetInfo>",
-    "SettingsSpec": "SettingsSpec",
+    # Primitive types
+    "Boolean": "boolean",
+    "Guid": "UUID",
+    "Int32": "number",
+    "Int32[]": "number[]",
+    "Int64": "number",
+    "JObject": "{ [key: string]: any }",
+    "Object": "any",
+    "String": "string",
+    "String[]": "string[]",
+    "Uri": "URL",
+    "Void": "void",
+
+    # Nested types
+    "Dictionary<String, Dictionary<String, MethodInfoSummary>>": "{ [key: string]: { [key: string]: any } }",
+    "Dictionary<String, Int32>": "{ [key: string]: number }",
+    "Dictionary<String, SettingSpec>": "{ [key: string]: SettingSpec }",
+    "Dictionary<String, String>": "{ [key: string]: string }",
+    "IDictionary<Guid, String>": "{ [key: UUID]: string }",
+    "IDictionary<String, String>": "{ [key: string]: string }",
+    "IEnumerable<ApplicationSpec>": "any[]",
+    "IEnumerable<AuthRoleSummary>": "any[]",
+    "IEnumerable<BackupManifest>": "any[]",
+    "IEnumerable<DeploymentTemplate>": "any[]",
+    "IEnumerable<EndpointInfo>": "EndpointInfo[]",
+    "IEnumerable<IADSInstance>": "IADSInstance[]",
+    "IEnumerable<IAuditLogEntry>": "any[]",
+    "IEnumerable<InstanceDatastore>": "InstanceDatastore[]",
+    "IEnumerable<JObject>": "{ [key: string]: any }[]",
+    "IEnumerable<ListeningPortSummary>": "any[]",
+    "IEnumerable<PortUsage>": "any[]",
+    "IEnumerable<ProvisionSettingInfo>": "any[]",
+    "IEnumerable<String>": "string[]",
+    "IEnumerable<UserInfo>": "UserInfo[]",
+    "IEnumerable<UserInfoSummary>": "any[]",
+    "IEnumerable<WebauthnCredentialSummary>": "any[]",
+    "IEnumerable<WebSessionSummary>": "any[]",
+    "IList<IPermissionsTreeNode>": "any[]",
+    "List<JObject>": "{ [key: string]: any }[]",
+    "List<String>": "string[]",
+    "Nullable<Boolean>": "boolean", # Optional?
+    "Nullable<DateTime>": "any", # Optional?
+
+    # Object types
+    "AuthRoleSummary": "any",
+    "ContainerMemoryPolicy": "any",
+    "DeploymentTemplate": "any",
+    "FileChunkData": "any",
+    "IADSInstance": "IADSInstance",
+    "Instance": "Instance",
+    "InstanceDatastore": "InstanceDatastore",
+    "LocalAMPInstance": "any",
+    "LoginResult": "LoginResult",
+    "ModuleInfo": "ModuleInfo",
+    "PortProtocol": "any",
+    "PostCreateActions": "any",
+    "RemoteTargetInfo": "RemoteTargetInfo",
+    "ScheduleInfo": "any",
+    "SimpleUser": "any",
+    "Single": "any",
     "Status": "Status",
+    "TimeIntervalTrigger": "any",
+    "UpdateInfo": "UpdateInfo",
     "Updates": "Updates",
-    "Result<{ [key: string]: string }>": "Result<{ [key: string]: string }>",
-    "LoginResult": "LoginResult"
+    "UserInfo": "UserInfo",
+    "WebauthnLoginInfo": "any",
 }
 
 custom_types = {
     # API.ADSModule.GetInstance
-    "ADSModule.GetInstance": "Result<Instance>",
-    # API.ADSModule.GetTargetInfo
-    "ADSModule.GetTargetInfo": "Result<RemoteTargetInfo>",
-
-    # API.Core.GetSettingsSpec
-    "Core.GetSettingsSpec": "SettingsSpec",
-    # API.Core.GetStatus
-    "Core.GetStatus": "Status",
-    # API.Core.GetUpdates
-    "Core.GetUpdates": "Updates",
-    # API.Core.GetUserList
-    "Core.GetUserList": "Result<{ [key: string]: string }>",
-    # API.Core.Login
-    "Core.Login": "LoginResult",
+    # "ADSModule.GetInstance": "Result<Instance>",
 }
 
 def generate_apimodule_method(module: str, method: str, method_spec: dict):
@@ -226,7 +213,7 @@ if __name__ == "__main__":
         branch = sys.argv[1]
 
     # Load remote file
-    res = requests.get(f"https://raw.githubusercontent.com/p0t4t0sandwich/ampapi-spec/{branch}/APISpec.json")
+    res = requests.get(f"https://raw.githubusercontent.com/p0t4t0sandwich/ampapi-spec/{branch}/OldAPISpec.json")
     spec = json.loads(res.content)
 
     # Load custom types

--- a/utils/templates/api_module.txt
+++ b/utils/templates/api_module.txt
@@ -4,7 +4,7 @@
  */
 
 import { AMPAPI } from "../AMPAPI.js";
-import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, Result, RunningTask, SettingsSpec, Spec, State, lookupState, Status, Task, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
+import { ActionResult, AMPVersion, Branding, ConsoleEntry, CPUInfo, EndpointInfo, IADSInstance, Instance, InstanceDatastore, LoginResult, Message, Metric, ModuleInfo, PlatformInfo, RemoteTargetInfo, RunningTask, SettingsSpec, Spec, State, lookupState, Status, UpdateInfo, Updates, UserInfo, URL, UUID, LicenceInfo } from "../types.js";
 
 
 /**


### PR DESCRIPTION
- All "result" fields have been removed
- Exceptions are now thrown when an API error is received
- New method added to GenericModule:
```diff
+ GenericModule.ImportConfig(filename: String) -> IDictionary<String, String>
```